### PR TITLE
Add Audio permission

### DIFF
--- a/harbour-lyrics.desktop
+++ b/harbour-lyrics.desktop
@@ -8,6 +8,6 @@ Name=Lyrics
 Comment=Music lyrics application
 
 [X-Sailjail]
-Permissions=Internet;Music
+Permissions=Audio;Internet
 OrganizationName=it.andreascarpino
 ApplicationName=harbour-lyrics


### PR DESCRIPTION
This change adds the "Audio" permission so that the "Media Player scanner" option works when the app is Sailjailed. This is a really nice feature, so personally I think it's worth adding the permission for.

For broader context: the permission allows the app to access the MPRIS metadata. From what I can tell, the permission is really intended for apps that want to show info on the homescreen (using MPRIS) but it seems to work for reading the MPRIS data too.

For reference:
1. [Audio permission description](https://github.com/sailfishos/sailjail-permissions#permissions)
2. [MPRIS dbus access](https://github.com/sailfishos/sailjail-permissions/blob/2cdb5e7f739e99ad4fd12e80cb1558eea4167f8e/permissions/Audio.permission#L29)