### PR TITLE
Delete lyrics on error

### DIFF
--- a/src/azlyrics.cpp
+++ b/src/azlyrics.cpp
@@ -44,7 +44,6 @@ AZLyrics::AZLyrics(QObject *parent) :
 
 AZLyrics::~AZLyrics()
 {
-    qDeleteAll(lyrics.keyBegin(), lyrics.keyEnd());
     qDeleteAll(lyrics);
     delete network;
 }
@@ -81,6 +80,7 @@ void AZLyrics::onGetLyricPageResult()
 
     if (reply->error() != QNetworkReply::NoError) {
         qCritical() << "Cannot fetch lyric:" << reply->errorString();
+        delete lyrics.take(reply);
     } else {
         QWebPage page;
         page.settings()->setAttribute(QWebSettings::AutoLoadImages, false);
@@ -91,6 +91,7 @@ void AZLyrics::onGetLyricPageResult()
 
         if (lyricbox.isNull()) {
             qCritical() << "Cannot find lyric text in HTML page";
+            delete lyrics.take(reply);
         } else {
             lyric = lyrics.take(reply);
 

--- a/src/geniusapi.cpp
+++ b/src/geniusapi.cpp
@@ -48,7 +48,6 @@ GeniusAPI::GeniusAPI(QObject *parent) :
 
 GeniusAPI::~GeniusAPI()
 {
-    qDeleteAll(lyrics.keyBegin(), lyrics.keyEnd());
     qDeleteAll(lyrics);
     delete network;
 }
@@ -144,6 +143,7 @@ void GeniusAPI::onGetLyricPageResult()
 
     if (reply->error() != QNetworkReply::NoError) {
         qCritical() << "Cannot fetch lyric";
+        delete lyrics.take(reply);
     } else {
         QWebPage page;
         page.settings()->setAttribute(QWebSettings::AutoLoadImages, false);
@@ -154,6 +154,7 @@ void GeniusAPI::onGetLyricPageResult()
 
         if (lyricbox.isNull()) {
             qCritical() << "Cannot find lyric box in HTML page";
+            delete lyrics.take(reply);
         } else {
             lyric = lyrics.take(reply);
 

--- a/src/lyricsmaniaapi.cpp
+++ b/src/lyricsmaniaapi.cpp
@@ -44,7 +44,6 @@ LyricsManiaAPI::LyricsManiaAPI(QObject *parent) :
 
 LyricsManiaAPI::~LyricsManiaAPI()
 {
-    qDeleteAll(lyrics.keyBegin(), lyrics.keyEnd());
     qDeleteAll(lyrics);
     delete network;
 }
@@ -81,6 +80,7 @@ void LyricsManiaAPI::onGetLyricPageResult()
 
     if (reply->error() != QNetworkReply::NoError) {
         qCritical() << "Cannot fetch lyric:" << reply->errorString();
+        delete lyrics.take(reply);
     } else {
         QWebPage page;
         page.settings()->setAttribute(QWebSettings::AutoLoadImages, false);
@@ -91,6 +91,7 @@ void LyricsManiaAPI::onGetLyricPageResult()
 
         if (lyricbox.isNull()) {
             qCritical() << "Cannot find lyric text in HTML page";
+            delete lyrics.take(reply);
         } else {
             // Remove the video div
             lyricbox.findFirst(QStringLiteral("div")).removeFromDocument();


### PR DESCRIPTION
When there's a network error, or the lyrics can't be found, the network reply and lyrics object need to be deleted from the lyrics map. This is necessary because the network reply will be deleted at the end of onGetLyricPageResult() anyway, so can no longer be used as a key in the map.

Removing the key should prevent the app crashing when the provider is changed after an unsuccessful search.